### PR TITLE
Update BHAT token status to inactive

### DIFF
--- a/tokens/BHAT-c1fde3/info.json
+++ b/tokens/BHAT-c1fde3/info.json
@@ -1,16 +1,16 @@
 {
-  "website": "https://bh.network/",
-  "description": "The BHAT Token is the epicenter of the BH Network web3 hub and allows access and interaction with all DeFi modules within the hub.",
+  "website": "",
+  "description": "The BH Network project has been officially closed. The BHAT token is no longer associated with an active project, product or roadmap. A voluntary airdrop was distributed to holders between September and December 2025.",
   "ledgerSignature": "30450221009bd94edb228d0810881b22f3e89a2d5617077ade5329e5ff2d9332cd179beb7f02205f15419fa374050b8d0dc38182ccf310e8f6cf8ea7a79eac64a5e20eec28ff7f",
   "social": {
-    "email": "contact@bh.network",
-    "blog": "https://bh.network/blog",
-    "twitter": "https://twitter.com/BlackHatNetwork",
-    "telegram": "https://t.me/bhnetwork",
-    "whitepaper": "https://bh.network/Whitepaper.pdf",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/bh-network/",
-    "discord": "https://discord.gg/bhnetwork",
-    "coingecko": "https://www.coingecko.com/en/coins/bhnetwork"
+    "email": "",
+    "blog": "",
+    "twitter": "",
+    "telegram": "",
+    "whitepaper": "",
+    "coinmarketcap": "",
+    "discord": "",
+    "coingecko": ""
   },
   "status": "active",
   "lockedAccounts": {


### PR DESCRIPTION
This PR updates the BHAT token information to reflect that the BH Network project has been officially closed.

BH Network AG in Liechtenstein has been liquidated and deregistered. The BHAT token is no longer associated with an active project, product or roadmap.

A voluntary airdrop was distributed to holders between Sept - Dec 2025.